### PR TITLE
Fix Android page alignment

### DIFF
--- a/bbqr-android/plugins/src/main/kotlin/org/bitcoinppl/bbqr/plugins/UniFfiAndroidPlugin.kt
+++ b/bbqr-android/plugins/src/main/kotlin/org/bitcoinppl/bbqr/plugins/UniFfiAndroidPlugin.kt
@@ -17,6 +17,17 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             OS.OTHER -> throw Error("Cannot build Android library from current architecture")
         }
 
+        val androidElfAlignmentRustFlags =
+            "-C link-arg=-Wl,-z,max-page-size=16384 -C link-arg=-Wl,-z,common-page-size=16384"
+
+        fun targetRustFlags(target: String): Pair<String, String> {
+            val envName = "CARGO_TARGET_${target.uppercase().replace("-", "_")}_RUSTFLAGS"
+            val existingRustFlags = System.getenv(envName)?.takeIf { it.isNotBlank() }
+            val rustFlags = listOfNotNull(existingRustFlags, androidElfAlignmentRustFlags).joinToString(" ")
+
+            return Pair(envName, rustFlags)
+        }
+
         // arm64-v8a is the most popular hardware architecture for Android
         val buildAndroidAarch64Binary by tasks.register<Exec>("buildAndroidAarch64Binary") {
 
@@ -29,6 +40,7 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             environment(
                 // add build toolchain to PATH
                 Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=21"),
+                targetRustFlags("aarch64-linux-android"),
             )
             doLast {
                 println("Native library for bbqr-android on aarch64 built successfully")
@@ -47,6 +59,7 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             environment(
                 // add build toolchain to PATH
                 Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=21"),
+                targetRustFlags("x86_64-linux-android"),
             )
 
             doLast {
@@ -66,6 +79,7 @@ internal class UniFfiAndroidPlugin : Plugin<Project> {
             environment(
                 // add build toolchain to PATH
                 Pair("CFLAGS", "-D__ANDROID_MIN_SDK_VERSION__=21"),
+                targetRustFlags("armv7-linux-androideabi"),
             )
 
             doLast {

--- a/bbqr-ffi/justfile
+++ b/bbqr-ffi/justfile
@@ -1,9 +1,11 @@
+android-rustflags := "-C link-arg=-Wl,-z,max-page-size=16384 -C link-arg=-Wl,-z,common-page-size=16384"
+
 gen:
   just gen-android
   just gen-swift
 
 gen-android:
-  cargo ndk --target aarch64-linux-android build --package bbqr-ffi 
+  CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS="${CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS:+$CARGO_TARGET_AARCH64_LINUX_ANDROID_RUSTFLAGS }{{android-rustflags}}" cargo ndk --target aarch64-linux-android build --package bbqr-ffi
   cargo run --bin uniffi-bindgen generate --library target/aarch64-linux-android/debug/libbbqrffi.so --config uniffi.toml --language kotlin --out-dir ../bbqr-android/lib/src/main/kotlin --no-format
 
 gen-swift:


### PR DESCRIPTION
Closes: #4 

  ## Summary

  - Build Android native libraries with 16 KB ELF segment alignment
  - Apply the linker flags in both the Gradle Android build tasks and local `just gen-android`
  - Preserve any existing target-specific Rust flags when adding the alignment flags


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Android build system with enhanced Rust linker flag management. These changes consolidate configuration across all supported Android architectures, ensuring proper memory alignment for more reliable builds and better app stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitcoinppl/bbqr-ffi/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->